### PR TITLE
✨ feat: Ignore server directory instead of nacin-os

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-nacin-os
+server


### PR DESCRIPTION
Modify the .gitignore file to ignore the server directory
instead of the nacin-os directory. This change is necessary
as the project structure has been updated and the server
directory is now the main focus of the application.